### PR TITLE
HEON-5 make sure we are using the correct version of keystonemiddleware

### DIFF
--- a/eon/api/acl.py
+++ b/eon/api/acl.py
@@ -1,5 +1,13 @@
 # -*- encoding: utf-8 -*-
 #
+# Modified By (c) Copyright 2017 Hewlett Packard Enterprise Development LP
+#
+# Confidential computer software. Valid license from HPE required for
+# possession, use or copying. Consistent with FAR 12.211 and 12.212,
+# Commercial Computer Software, Computer Software Documentation, and Technical
+# Data for Commercial Items are licensed to the U.S. Government under vendor's
+# standard commercial license.
+#
 # Copyright © 2012 New Dream Network, LLC (DreamHost)
 #
 # Author: Doug Hellmann <doug.hellmann@dreamhost.com>

--- a/eon/tests/unit/api/test_acl.py
+++ b/eon/tests/unit/api/test_acl.py
@@ -26,9 +26,9 @@ class TestACL(base_test.TestCase):
     def test_install_auth(self):
         app = mock.MagicMock()
         public_routes = mock.MagicMock()
-        acl.install_auth(app, cfg.CONF, public_routes)
+        auth_token = acl.install_auth(app, cfg.CONF, public_routes)
 
     def test_install_audit(self):
         app = mock.MagicMock()
         public_routes = mock.MagicMock()
-        acl.install_audit(app, cfg.CONF, public_routes)
+        auth_token = acl.install_audit(app, cfg.CONF, public_routes)

--- a/eon/tests/unit/conductor/v2/test_rpcapi.py
+++ b/eon/tests/unit/conductor/v2/test_rpcapi.py
@@ -28,9 +28,10 @@ class TestConductorAPI(base_test.TestCase):
     def setUp(self, mock_transport):
         base_test.TestCase.setUp(self)
         conductor_rpcapi.proxy = mock.MagicMock()
-        conf = mock.MagicMock()
-        conf.transport_url = "rabbit://me:passwd@host:5672/virtual_host"
-        rpc.init(conf)
+        # NOTE(gyee): we really don't care about actually using oslo_messaging
+        # so we can just mock them.
+        rpc.TRANSPORT = mock.MagicMock()
+        rpc.NOTIFIER = mock.MagicMock()
         self.rpcapi = conductor_rpcapi.ConductorAPI(topic="fake-topic")
 
     def _test_rpcapi(self, method, *args, **kwargs):

--- a/eon/virt/hyperv/driver.py
+++ b/eon/virt/hyperv/driver.py
@@ -24,6 +24,7 @@ from eon.virt.common import utils as vir_utils
 from eon.common import exception
 import eon.db
 from oslo_config import cfg
+from oslo_config import types as oslo_config_types
 from eon.virt.hyperv import hyperv_utils
 
 LOG = logging.getLogger(__name__)
@@ -31,6 +32,7 @@ LOG = logging.getLogger(__name__)
 CONF = cfg.CONF
 HYPERV_ROOT_ACTIONS_OPTS = [
     cfg.ListOpt('supported_os_editions',
+               item_type=oslo_config_types.Integer(),
                default=[7, 8, 12, 13, 42],
                help='Supported Hyper-V host OS editions'),
 ]

--- a/install_external_deps
+++ b/install_external_deps
@@ -1,0 +1,46 @@
+#!/bin/bash
+# (c) Copyright 2016-2017 Hewlett Packard Enterprise Development LP
+#
+# Confidential computer software. Valid license from HPE required for
+# possession, use or copying. Consistent with FAR 12.211 and 12.212,
+# Commercial Computer Software, Computer Software Documentation, and Technical
+# Data for Commercial Items are licensed to the U.S. Government under vendor's
+# standard commercial license.
+
+set -eu
+git_remote=$(git remote -v | grep origin | awk -F " " '{print $2}' | sed 1,1d)
+printf "git url being used - $git_remote \n\n"
+git_base_url=${git_remote%/*/*}
+printf "base url being used - $git_base_url \n\n"
+
+branch_name="hp/prerelease/newton"
+
+# egg_branch_array is an associative array with egg name
+# as the key and branchname as the value
+declare -A egg_branch_array
+egg_branch_array=( ["keystonemiddleware"]="$branch_name" )
+# to add more, do something like this:
+# egg_branch_array=( ["aceclient-1.0.0"]="ace_branch" ["siriusclient-1.0.0"]="sirius_branch")
+# for overriding branches just replace the variable with the branch name
+
+# egg_project_array is an associative array with egg name
+# as the key and project as the value
+declare -A egg_project_array
+egg_project_array=( ["keystonemiddleware"]="openstack/keystonemiddleware")
+# The above variable is required to find the project's git name .
+# This could have been avoided if there would have been a relationship
+# between the egg and the git.
+
+# to add more, do something like this:
+#egg_project_array=( ["aceclient-1.0.0"]="cloudsystem-ace-client" ["siriusclient-1.0.0"]="python-siriusclient")
+egg_names=(${!egg_branch_array[@]})
+for (( I=0; $I < ${#egg_branch_array[@]}; I+=1 )); do
+    e_name=${egg_names[$I]}
+    b_name=${egg_branch_array[$e_name]}
+    p_name=${egg_project_array[$e_name]}
+    echo "*****************"
+    url="git+""$git_base_url/$p_name@$b_name#egg=$e_name"
+    echo "executing command - pip install -e $url | tee intall_external_deps.log"
+    echo "*****************"
+    echo `pip install -e $url | tee install_external_deps.log`
+done


### PR DESCRIPTION
keystonemiddleware has been drastically refactored in Newton release. Since
EON is extending keystonemiddleware, we need to adjust the code accordingly.
In the long run, we really really really need to refactor this code to make
use of keystonemiddleware public interfaces instead of extending them.

This patch also fixed the broken code in driver.py. The Hyper-V editions should
be a number list, from what I can tell. So we need to make sure the data
types are consistent throughout.

Change-Id: If376ef628c8df556c0b66a83caab6b918c45cebf
(cherry picked from commit 03bc0c6ac43e330a6c66f0357a067fbe548b236a)
(cherry picked from commit 35e202e923d9ac99cd48e3d1a8ba1ec64f7cd5b6)